### PR TITLE
use a consistent text layouting algorithm

### DIFF
--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-print",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "print an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-print/src/index.js
+++ b/packages/plugin-print/src/index.js
@@ -1,7 +1,7 @@
 import Path from 'path';
 import bMFont from 'load-bmfont';
 import { isNodePattern, throwError } from '@jimp/utils';
-import { measureText, measureTextHeight } from './measure-text';
+import { measureText, measureTextHeight, splitLines } from './measure-text';
 
 function xOffsetBasedOnAlignment(constants, font, line, maxWidth, alignment) {
   if (alignment === constants.HORIZONTAL_ALIGN_LEFT) {
@@ -55,36 +55,6 @@ function printText(font, x, y, text, defaultCharWidth) {
 
     x += kerning + (fontChar.xadvance || defaultCharWidth);
   }
-}
-
-function splitLines(font, text, maxWidth) {
-  const words = text.split(' ');
-  const lines = [];
-  let currentLine = [];
-  let longestLine = 0;
-
-  words.forEach(word => {
-    const line = [...currentLine, word].join(' ');
-    const length = measureText(font, line);
-
-    if (length <= maxWidth) {
-      if (length > longestLine) {
-        longestLine = length;
-      }
-
-      currentLine.push(word);
-    } else {
-      lines.push(currentLine);
-      currentLine = [word];
-    }
-  });
-
-  lines.push(currentLine);
-
-  return {
-    lines,
-    longestLine
-  };
 }
 
 function loadPages(Jimp, dir, pages) {

--- a/packages/plugin-print/src/measure-text.js
+++ b/packages/plugin-print/src/measure-text.js
@@ -15,22 +15,38 @@ export function measureText(font, text) {
   return x;
 }
 
-export function measureTextHeight(font, text, maxWidth) {
+export function splitLines(font, text, maxWidth) {
   const words = text.split(' ');
-  let line = '';
-  let textTotalHeight = font.common.lineHeight;
+  const lines = [];
+  let currentLine = [];
+  let longestLine = 0;
 
-  for (let n = 0; n < words.length; n++) {
-    const testLine = line + words[n] + ' ';
-    const testWidth = measureText(font, testLine);
+  words.forEach(word => {
+    const line = [...currentLine, word].join(' ');
+    const length = measureText(font, line);
 
-    if (testWidth > maxWidth && n > 0) {
-      textTotalHeight += font.common.lineHeight;
-      line = words[n] + ' ';
+    if (length <= maxWidth) {
+      if (length > longestLine) {
+        longestLine = length;
+      }
+
+      currentLine.push(word);
     } else {
-      line = testLine;
+      lines.push(currentLine);
+      currentLine = [word];
     }
-  }
+  });
 
-  return textTotalHeight;
+  lines.push(currentLine);
+
+  return {
+    lines,
+    longestLine
+  };
+}
+
+export function measureTextHeight(font, text, maxWidth) {
+  const { lines } = splitLines(font, text, maxWidth);
+
+  return lines.length * font.common.lineHeight;
 }

--- a/packages/plugin-print/test/print.test.js
+++ b/packages/plugin-print/test/print.test.js
@@ -281,4 +281,15 @@ describe('Write text over image', function() {
 
     expectedImage.bitmap.data.should.be.deepEqual(image.bitmap.data);
   });
+
+  it('measureText is consistent with measureTextWidth', async () => {
+    const font = await jimp.loadFont(Jimp.FONT_SANS_16_BLACK);
+
+    const text = 'n n n';
+    const width = jimp.measureText(font, text);
+    const height = jimp.measureTextHeight(font, text, width);
+    const lineHeight = jimp.measureTextHeight(font, text, Infinity);
+
+    height.should.be.deepEqual(lineHeight);
+  });
 });


### PR DESCRIPTION
# What's Changing and Why

In the `print` plugin, there are two places where the text is split in lines no longer than `maxWidth`. They all use slightly different algorithms, which produces inconsistent results. This PR fixes that by using the `splitLines()` function in both places.

## What else might be affected

While it is, technically, a breaking change, I am fairly sure that nothing breaks because the behavior was both unexpected and undocumented.

## Tasks

- [x] Add tests
- [x] Update Documentation (not needed)
- [x] Update `jimp.d.ts` (not needed)
- [x] Add [SemVer](https://semver.org/) Label
