### PR TITLE
Fix EDGE_WRAP overwriting X with Y when Y < 0

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -25,9 +25,10 @@ const alphabet =
 const maxHashLength = [NaN, NaN];
 
 for (let i = 2; i < 65; i++) {
-  const maxHash = anyBase(anyBase.BIN, alphabet.slice(0, i))(
-    new Array(64 + 1).join('1')
-  );
+  const maxHash = anyBase(
+    anyBase.BIN,
+    alphabet.slice(0, i)
+  )(new Array(64 + 1).join('1'));
   maxHashLength.push(maxHash.length);
 }
 
@@ -713,7 +714,7 @@ class Jimp extends EventEmitter {
       }
 
       if (y < 0) {
-        xi = this.bitmap.height + y;
+        yi = this.bitmap.height + y;
       }
 
       if (y >= this.bitmap.height) {

--- a/packages/plugin-color/test/convolution.test.js
+++ b/packages/plugin-color/test/convolution.test.js
@@ -49,7 +49,11 @@ describe('Convolution', function() {
       .catch(done);
   });
 
-  const sharpM = [[-1, -1, 0], [-1, 1, 1], [0, 1, 1]];
+  const sharpM = [
+    [-1, -1, 0],
+    [-1, 1, 1],
+    [0, 1, 1]
+  ];
 
   it('3x3 sharp matrix on EDGE_EXTEND', done => {
     imgMid
@@ -96,7 +100,7 @@ describe('Convolution', function() {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
-          '66666666',
+          '22222222',
           '28EEE822',
           '2EFFF802',
           '2EF88002',
@@ -113,7 +117,7 @@ describe('Convolution', function() {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
-          'FC06666F',
+          'F802222E',
           '80022228',
           '00022222',
           '22222222',


### PR DESCRIPTION
# What's Changing and Why
The getPixelAt code in the Jimp core seems to be doing the wrong thing when EdgeHandling is set to EDGE_WRAP. When ``y`` is lower than zero, it assigns the wrapped ``y`` value to ``xi`` instead of ``yi``, resulting in distorted output. This pull request changes the variable assignment to the correct value. I've updated the corresponding test as well so that the buffers match during the test.

## What else might be affected
Any code that uses edge wrap may see different output in cases where the image is sampled on the negative Y axis.

## Tasks

- [X] Add tests
- [ ] Update Documentation 
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.2-canary.956.1095.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.16.2-canary.956.1095.0
  npm install @jimp/core@0.16.2-canary.956.1095.0
  npm install @jimp/custom@0.16.2-canary.956.1095.0
  npm install jimp@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-blit@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-blur@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-circle@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-color@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-contain@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-cover@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-crop@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-displace@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-dither@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-fisheye@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-flip@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-gaussian@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-invert@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-mask@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-normalize@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-print@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-resize@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-rotate@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-scale@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-shadow@0.16.2-canary.956.1095.0
  npm install @jimp/plugin-threshold@0.16.2-canary.956.1095.0
  npm install @jimp/plugins@0.16.2-canary.956.1095.0
  npm install @jimp/test-utils@0.16.2-canary.956.1095.0
  npm install @jimp/bmp@0.16.2-canary.956.1095.0
  npm install @jimp/gif@0.16.2-canary.956.1095.0
  npm install @jimp/jpeg@0.16.2-canary.956.1095.0
  npm install @jimp/png@0.16.2-canary.956.1095.0
  npm install @jimp/tiff@0.16.2-canary.956.1095.0
  npm install @jimp/types@0.16.2-canary.956.1095.0
  npm install @jimp/utils@0.16.2-canary.956.1095.0
  # or 
  yarn add @jimp/cli@0.16.2-canary.956.1095.0
  yarn add @jimp/core@0.16.2-canary.956.1095.0
  yarn add @jimp/custom@0.16.2-canary.956.1095.0
  yarn add jimp@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-blit@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-blur@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-circle@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-color@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-contain@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-cover@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-crop@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-displace@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-dither@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-fisheye@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-flip@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-gaussian@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-invert@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-mask@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-normalize@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-print@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-resize@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-rotate@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-scale@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-shadow@0.16.2-canary.956.1095.0
  yarn add @jimp/plugin-threshold@0.16.2-canary.956.1095.0
  yarn add @jimp/plugins@0.16.2-canary.956.1095.0
  yarn add @jimp/test-utils@0.16.2-canary.956.1095.0
  yarn add @jimp/bmp@0.16.2-canary.956.1095.0
  yarn add @jimp/gif@0.16.2-canary.956.1095.0
  yarn add @jimp/jpeg@0.16.2-canary.956.1095.0
  yarn add @jimp/png@0.16.2-canary.956.1095.0
  yarn add @jimp/tiff@0.16.2-canary.956.1095.0
  yarn add @jimp/types@0.16.2-canary.956.1095.0
  yarn add @jimp/utils@0.16.2-canary.956.1095.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
