### PR TITLE
Remove load-bmfont dependency from core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,6 @@
     "buffer": "^5.2.0",
     "exif-parser": "^0.1.12",
     "file-type": "^9.0.0",
-    "load-bmfont": "^1.3.1",
     "mkdirp": "^0.5.1",
     "phin": "^2.9.1",
     "pixelmatch": "^4.0.2",


### PR DESCRIPTION
# What's Changing and Why

Looking at dependencies in a project using jimp I wondered why old package versions were pulled. Turns out that an old load-bmfont was pulled from jimp core. I wondered if I should propose a dependency bump but the package seem unused by core. And the only packages that uses this dependency (plugin-print) is already requiring a more up-to-date version ( https://github.com/oliver-moran/jimp/blob/master/packages/plugin-print/package.json#L25 ) so I suggest to remove it.

## What else might be affected

If some users depends of the side-effect that depending on jimp-core pull load-bmfont in their dependency tree they will break.

## Tasks

- [ ] ~Add tests~
- [ ] ~Update Documentation~
- [ ] ~Update `jimp.d.ts`~
- [ ] ~Add [SemVer](https://semver.org/) Label~

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.2-canary.1008.1164.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.16.2-canary.1008.1164.0
  npm install @jimp/core@0.16.2-canary.1008.1164.0
  npm install @jimp/custom@0.16.2-canary.1008.1164.0
  npm install jimp@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-blit@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-blur@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-circle@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-color@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-contain@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-cover@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-crop@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-displace@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-dither@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-fisheye@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-flip@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-gaussian@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-invert@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-mask@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-normalize@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-print@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-resize@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-rotate@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-scale@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-shadow@0.16.2-canary.1008.1164.0
  npm install @jimp/plugin-threshold@0.16.2-canary.1008.1164.0
  npm install @jimp/plugins@0.16.2-canary.1008.1164.0
  npm install @jimp/test-utils@0.16.2-canary.1008.1164.0
  npm install @jimp/bmp@0.16.2-canary.1008.1164.0
  npm install @jimp/gif@0.16.2-canary.1008.1164.0
  npm install @jimp/jpeg@0.16.2-canary.1008.1164.0
  npm install @jimp/png@0.16.2-canary.1008.1164.0
  npm install @jimp/tiff@0.16.2-canary.1008.1164.0
  npm install @jimp/types@0.16.2-canary.1008.1164.0
  npm install @jimp/utils@0.16.2-canary.1008.1164.0
  # or 
  yarn add @jimp/cli@0.16.2-canary.1008.1164.0
  yarn add @jimp/core@0.16.2-canary.1008.1164.0
  yarn add @jimp/custom@0.16.2-canary.1008.1164.0
  yarn add jimp@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-blit@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-blur@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-circle@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-color@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-contain@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-cover@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-crop@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-displace@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-dither@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-fisheye@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-flip@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-gaussian@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-invert@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-mask@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-normalize@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-print@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-resize@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-rotate@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-scale@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-shadow@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugin-threshold@0.16.2-canary.1008.1164.0
  yarn add @jimp/plugins@0.16.2-canary.1008.1164.0
  yarn add @jimp/test-utils@0.16.2-canary.1008.1164.0
  yarn add @jimp/bmp@0.16.2-canary.1008.1164.0
  yarn add @jimp/gif@0.16.2-canary.1008.1164.0
  yarn add @jimp/jpeg@0.16.2-canary.1008.1164.0
  yarn add @jimp/png@0.16.2-canary.1008.1164.0
  yarn add @jimp/tiff@0.16.2-canary.1008.1164.0
  yarn add @jimp/types@0.16.2-canary.1008.1164.0
  yarn add @jimp/utils@0.16.2-canary.1008.1164.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
