### PR TITLE
fix: scaleTofit factor calc fixed

### DIFF
--- a/packages/plugin-scale/src/index.js
+++ b/packages/plugin-scale/src/index.js
@@ -51,10 +51,7 @@ export default () => ({
       mode = null;
     }
 
-    const f =
-      w / h > this.bitmap.width / this.bitmap.height
-        ? h / this.bitmap.height
-        : w / this.bitmap.width;
+    const f = Math.max(w / this.bitmap.width, h / this.bitmap.height);
     this.scale(f, mode);
 
     if (isNodePattern(cb)) {


### PR DESCRIPTION
# What's Changing and Why

const w = 2120, h = 1280
const bitmap = { width: 42, height: 37 }

const factorW = w / bitmap.width = 2120 / 42 = 50.47
const factorH = h / bitmap.height = 1280 / 37 = 34.59
In this case , I think factorW is the right factor.

old version : 
w / h  = 2120 / 1280 = 1.65625
bitmap.width / bitmap.height = 42 / 37 = 1.135
so factor = factorH

## What else might be affected
no

## Tasks

- [ no required ] Add tests
- [ no required] Update Documentation
- [ no required ] Update `jimp.d.ts`
- [ no required ] Add [SemVer](https://semver.org/) Label
