### PR TITLE
fix documentation about rotation direction.

### DIFF
--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -226,7 +226,7 @@ image.convolute( kernel );        // applies a convolution kernel matrix to the 
 /* Flip and rotate */
 image.flip( horz, vert );         // flip the image horizontally or vertically
 image.mirror( horz, vert );       // an alias for flip
-image.rotate( deg[, mode] );      // rotate the image clockwise by a number of degrees. Optionally, a resize mode can be passed. If `false` is passed as the second parameter, the image width and height will not be resized.
+image.rotate( deg[, mode] );      // rotate the image counter-clockwise by a number of degrees. Optionally, a resize mode can be passed. If `false` is passed as the second parameter, the image width and height will not be resized.
 
 /* Colour */
 image.brightness( val );          // adjust the brighness by a value -1 to +1

--- a/packages/plugin-rotate/README.md
+++ b/packages/plugin-rotate/README.md
@@ -5,11 +5,11 @@
   <p>Rotate an image.</p>
 </div>
 
-Rotates the image clockwise by a number of degrees. By default the width and height of the image will be resized appropriately.
+Rotates the image counter-clockwise by a number of degrees. By default the width and height of the image will be resized appropriately.
 
 ## Usage
 
-- @param {number} deg the number of degrees to rotate the image by
+- @param {number} deg the number of degrees to rotate the image by, counter-clockwise
 - @param {string|boolean} mode (optional) resize mode or a boolean, if false then the width and height of the image will not be changed
 - @param {function(Error, Jimp)} cb (optional) a callback for when complete
 

--- a/packages/plugin-rotate/src/index.js
+++ b/packages/plugin-rotate/src/index.js
@@ -1,7 +1,7 @@
 import { throwError, isNodePattern } from '@jimp/utils';
 
 /**
- * Rotates an image clockwise by an arbitrary number of degrees. NB: 'this' must be a Jimp object.
+ * Rotates an image counter-clockwise by an arbitrary number of degrees. NB: 'this' must be a Jimp object.
  * @param {number} deg the number of degrees to rotate the image by
  * @param {string|boolean} mode (optional) resize mode or a boolean, if false then the width and height of the image will not be changed
  */
@@ -110,7 +110,7 @@ function advancedRotate(deg, mode) {
 
 export default () => ({
   /**
-   * Rotates the image clockwise by a number of degrees. By default the width and height of the image will be resized appropriately.
+   * Rotates the image counter-clockwise by a number of degrees. By default the width and height of the image will be resized appropriately.
    * @param {number} deg the number of degrees to rotate the image by
    * @param {string|boolean} mode (optional) resize mode or a boolean, if false then the width and height of the image will not be changed
    * @param {function(Error, Jimp)} cb (optional) a callback for when complete


### PR DESCRIPTION
as of the current implementation, positive numbers rotate counter-clockwise while negative numbers rotate clockwise.
changing the implementation would be a breaking change, so fixing the documentation probably is the better way.

refs #631

# What's Changing and Why

## What else might be affected

## Tasks

- [ ] Add tests
- [x] Update Documentation
- [ ] Update `jimp.d.ts`
- [x] Add [SemVer](https://semver.org/) Label
