### PR TITLE
Fix rotate clockwise angle

### DIFF
--- a/packages/plugin-rotate/src/index.js
+++ b/packages/plugin-rotate/src/index.js
@@ -82,8 +82,8 @@ function advancedRotate(deg, mode) {
     for (let x = 1; x <= bW; x++) {
       const cartesian = translate2Cartesian(x, y);
       const source = translate2Screen(
-        cosine * cartesian.x - sine * cartesian.y,
-        cosine * cartesian.y + sine * cartesian.x
+        cosine * cartesian.x + sine * cartesian.y,
+        cosine * cartesian.y - sine * cartesian.x
       );
       const dstIdx = (bW * (y - 1) + x - 1) << 2;
 

--- a/packages/plugin-rotate/test/rotation.test.js
+++ b/packages/plugin-rotate/test/rotation.test.js
@@ -53,10 +53,52 @@ describe('Rotate a image with even size', () => {
       );
   });
 
+  it('-1 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-1, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '▰▴▴▴▪▪▪▰  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▦▪▪▪▴▴▴▦  ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
   it('91 degrees', () => {
     imgSrc
       .clone()
       .rotate(91, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          ' ▦▪▪▪▴▴▴▰ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▦▴▴▴▪▪▪▰ ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-91 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-91, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -81,6 +123,29 @@ describe('Rotate a image with even size', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          '   ▴▴▴      ',
+          '   ▴▴▴▴▪    ',
+          '  ▴▴▴▴▴▪▪   ',
+          ' ▪▪▴▴▴▪▪▪▪▰ ',
+          ' ▪▪▪▪▪▪▪▪▪  ',
+          '▦▪▪▪▪▴▴▪▪▪  ',
+          '▦▪▪▪▴▴▴▴▪   ',
+          '  ▪▪▴▴▴▴    ',
+          '    ▴▴▴▴    ',
+          '     ▴▦     ',
+          '            ',
+          '            '
+        )
+      );
+  });
+
+  it('-30 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-30, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           '     ▰▰     ',
           '   ▪▪▪▪     ',
           '  ▴▪▪▪▪▪    ',
@@ -101,6 +166,31 @@ describe('Rotate a image with even size', () => {
     imgSrc
       .clone()
       .rotate(45, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '      ▰       ',
+          '     ▴▰▴      ',
+          '    ▴▴▴▴▴     ',
+          '   ▪▴▴▴▴▴▪    ',
+          '  ▪▪▪▴▴▴▪▪▪   ',
+          ' ▦▪▪▪▪▴▪▪▪▪▰  ',
+          '  ▪▪▪▪▴▪▪▪▪   ',
+          '   ▪▪▴▴▴▪▪    ',
+          '    ▴▴▴▴▴     ',
+          '     ▴▴▴      ',
+          '      ▦       ',
+          '              ',
+          '              ',
+          '              '
+        )
+      );
+  });
+
+  it('-45 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-45, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -129,6 +219,29 @@ describe('Rotate a image with even size', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          '     ▴▴▴    ',
+          '   ▪▴▴▴▴    ',
+          '  ▪▪▴▴▴▴▴   ',
+          '▦▪▪▪▪▴▴▴▪▪  ',
+          ' ▪▪▪▪▪▪▪▪▪  ',
+          ' ▪▪▪▴▴▪▪▪▪▰ ',
+          '  ▪▴▴▴▴▪▪▪▰ ',
+          '   ▴▴▴▴▪▪   ',
+          '   ▴▴▴▴     ',
+          '    ▦▴      ',
+          '            ',
+          '            '
+        )
+      );
+  });
+
+  it('-60 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-60, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           '   ▰        ',
           '   ▪▪▪      ',
           '  ▪▪▪▪▪     ',
@@ -149,6 +262,27 @@ describe('Rotate a image with even size', () => {
     imgSrc
       .clone()
       .rotate(90, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          ' ▦▪▪▪▴▴▴▰ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▦▴▴▴▪▪▪▰ ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-90 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-90, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -173,6 +307,29 @@ describe('Rotate a image with even size', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          '    ▦▦      ',
+          '    ▪▪▪▪    ',
+          '   ▪▪▪▪▪▴   ',
+          '   ▪▪▪▪▴▴▴▴ ',
+          '  ▴▴▴▪▪▴▴▴▴ ',
+          ' ▴▴▴▴▴▪▴▴▴▴ ',
+          ' ▦▴▴▴▴▪▪▴▴  ',
+          '  ▴▴▴▪▪▪▪▪  ',
+          '    ▪▪▪▪▪   ',
+          '     ▪▪▪    ',
+          '       ▰    ',
+          '            '
+        )
+      );
+  });
+
+  it('-120 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-120, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           '            ',
           '     ▴▦     ',
           '    ▴▴▴▴    ',
@@ -193,6 +350,31 @@ describe('Rotate a image with even size', () => {
     imgSrc
       .clone()
       .rotate(135, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '              ',
+          '       ▦      ',
+          '      ▪▪▪     ',
+          '     ▪▪▪▪▪    ',
+          '    ▴▪▪▪▪▴▴   ',
+          '   ▴▴▴▪▪▴▴▴▴  ',
+          '  ▦▴▴▴▴▴▴▴▴▰▰ ',
+          '   ▴▴▴▪▪▴▴▴▴  ',
+          '    ▴▪▪▪▪▴▴   ',
+          '     ▪▪▪▪▪    ',
+          '      ▪▪▪     ',
+          '       ▰      ',
+          '              ',
+          '              '
+        )
+      );
+  });
+
+  it('-135 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-135, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -235,10 +417,56 @@ describe('Rotate a image with even size', () => {
       );
   });
 
+  it('-180 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-180, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '          ',
+          ' ▦▴▴▴▪▪▪▦ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▴▴▴▴▪▪▪▪ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▰▪▪▪▴▴▴▰ ',
+          '          '
+        )
+      );
+  });
+
   it('225 degrees', () => {
     imgSrc
       .clone()
       .rotate(225, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '              ',
+          '              ',
+          '      ▦       ',
+          '     ▴▴▴      ',
+          '    ▴▴▴▴▴     ',
+          '   ▪▪▴▴▴▪▪    ',
+          '  ▪▪▪▪▴▪▪▪▪   ',
+          ' ▰▪▪▪▪▴▪▪▪▪▦  ',
+          '  ▪▪▪▴▴▴▪▪▪   ',
+          '   ▪▴▴▴▴▴▪    ',
+          '    ▴▴▴▴▴     ',
+          '     ▴▰▴      ',
+          '      ▰       ',
+          '              '
+        )
+      );
+  });
+
+  it('-225 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-225, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -267,6 +495,27 @@ describe('Rotate a image with even size', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          '          ',
+          '▰▪▪▪▴▴▴▦  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▰▴▴▴▪▪▪▦  ',
+          '          '
+        )
+      );
+  });
+
+  it('-270 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-270, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           ' ▦▪▪▪▴▴▴▰ ',
           ' ▪▪▪▪▴▴▴▴ ',
           ' ▪▪▪▪▴▴▴▴ ',
@@ -285,6 +534,31 @@ describe('Rotate a image with even size', () => {
     imgSrc
       .clone()
       .rotate(315, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '              ',
+          '     ▰        ',
+          '    ▪▪▪       ',
+          '   ▪▪▪▪▪      ',
+          '  ▴▴▪▪▪▪▴     ',
+          ' ▴▴▴▴▪▪▴▴▴    ',
+          '▰▰▴▴▴▴▴▴▴▴▦   ',
+          ' ▴▴▴▴▪▪▴▴▴    ',
+          '  ▴▴▪▪▪▪▴     ',
+          '   ▪▪▪▪▪      ',
+          '    ▪▪▪       ',
+          '     ▦        ',
+          '              ',
+          '              '
+        )
+      );
+  });
+
+  it('-315 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-315, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -310,6 +584,27 @@ describe('Rotate a image with even size', () => {
     imgSrc
       .clone()
       .rotate(360, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '▰▴▴▴▪▪▪▰  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▪▪▪▪▴▴▴▴  ',
+          '▦▪▪▪▴▴▴▦  ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-360 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-360, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -358,6 +653,29 @@ describe('Rotate a image with odd size', () => {
       .should.be.sameJGD(
         mkJGD(
           '            ',
+          '     ▴      ',
+          '    ▴▴▴     ',
+          '   ▦▴▴▴▦    ',
+          '  ▴▴▦▴▦▪▪   ',
+          ' ▴▴▴▴▦▪▪▪▪  ',
+          '  ▴▴▦▴▦▪▪   ',
+          '   ▦▴▴▴▦    ',
+          '    ▴▴▴     ',
+          '     ▴      ',
+          '            ',
+          '            '
+        )
+      );
+  });
+
+  it('-45 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-45, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '            ',
           '     ▪      ',
           '    ▪▪▪     ',
           '   ▦▪▪▪▦    ',
@@ -377,6 +695,29 @@ describe('Rotate a image with odd size', () => {
     imgSrc
       .clone()
       .rotate(135, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '            ',
+          '     ▴      ',
+          '    ▴▴▴     ',
+          '   ▦▴▴▴▦    ',
+          '  ▴▴▦▴▦▴▴   ',
+          ' ▴▴▴▴▦▴▴▴▴  ',
+          '  ▴▴▦▪▦▴▴   ',
+          '   ▦▪▪▪▦    ',
+          '    ▪▪▪     ',
+          '     ▪      ',
+          '            ',
+          '            '
+        )
+      );
+  });
+
+  it('-135 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-135, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -407,6 +748,29 @@ describe('Rotate a image with odd size', () => {
           '     ▴      ',
           '    ▴▴▴     ',
           '   ▦▴▴▴▦    ',
+          '  ▪▪▦▴▦▴▴   ',
+          ' ▪▪▪▪▦▴▴▴▴  ',
+          '  ▪▪▦▴▦▴▴   ',
+          '   ▦▴▴▴▦    ',
+          '    ▴▴▴     ',
+          '     ▴      ',
+          '            ',
+          '            '
+        )
+      );
+  });
+
+  it('-225 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-225, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '            ',
+          '     ▴      ',
+          '    ▴▴▴     ',
+          '   ▦▴▴▴▦    ',
           '  ▴▴▦▴▦▴▴   ',
           ' ▴▴▴▴▦▴▴▴▴  ',
           '  ▴▴▦▪▦▴▴   ',
@@ -423,6 +787,29 @@ describe('Rotate a image with odd size', () => {
     imgSrc
       .clone()
       .rotate(315, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '            ',
+          '     ▪      ',
+          '    ▪▪▪     ',
+          '   ▦▪▪▪▦    ',
+          '  ▴▴▦▪▦▴▴   ',
+          ' ▴▴▴▴▦▴▴▴▴  ',
+          '  ▴▴▦▴▦▴▴   ',
+          '   ▦▴▴▴▦    ',
+          '    ▴▴▴     ',
+          '     ▴      ',
+          '            ',
+          '            '
+        )
+      );
+  });
+
+  it('-315 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-315, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -479,6 +866,25 @@ describe('Rotate a non-square image', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          '▴▴        ',
+          '▴▴▴▴▪▪▪▪  ',
+          '▦▦▴▴▪▪▪▪  ',
+          '▦▦▦▦▴▴▴▪  ',
+          '  ▦▦▴▴▴▴  ',
+          '       ▴  ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-10 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-10, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           '       ▪  ',
           ' ▴▴▴▪▪▪▪  ',
           '▴▴▴▴▪▪▪▴  ',
@@ -495,6 +901,27 @@ describe('Rotate a non-square image', () => {
     imgSrc
       .clone()
       .rotate(30, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '  ▴       ',
+          ' ▴▴▴      ',
+          '▦▦▴▴▴▪    ',
+          '▦▦▦▦▪▪▪▪  ',
+          '  ▦▦▴▴▪▪▪ ',
+          '   ▴▴▴▴▪  ',
+          '     ▴▴   ',
+          '          ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-30 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-30, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -519,6 +946,27 @@ describe('Rotate a non-square image', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          '  ▴▴      ',
+          ' ▦▴▴▴     ',
+          '▦▦▦▴▴▴    ',
+          ' ▦▦▦▴▪▪   ',
+          '  ▦▦▴▪▪▪  ',
+          '   ▴▴▴▪▪  ',
+          '    ▴▴▴   ',
+          '     ▴    ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-45 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-45, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           '          ',
           '    ▪▪    ',
           '   ▪▪▪▴   ',
@@ -540,6 +988,27 @@ describe('Rotate a non-square image', () => {
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
+          ' ▦▦▴▴ ',
+          ' ▦▦▴▴ ',
+          ' ▦▦▴▴ ',
+          ' ▦▦▴▴ ',
+          ' ▴▴▪▪ ',
+          ' ▴▴▪▪ ',
+          ' ▴▴▪▪ ',
+          ' ▴▴▪▪ ',
+          '      ',
+          '      '
+        )
+      );
+  });
+
+  it('-90 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-90, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
           '      ',
           '▪▪▴▴  ',
           '▪▪▴▴  ',
@@ -558,6 +1027,27 @@ describe('Rotate a non-square image', () => {
     imgSrc
       .clone()
       .rotate(135, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '      ▦   ',
+          '     ▦▦▦  ',
+          '    ▦▦▦▴▴ ',
+          '   ▴▦▦▴▴▴ ',
+          '  ▴▴▴▴▴▴  ',
+          ' ▴▴▴▪▪▴   ',
+          '  ▴▪▪▪    ',
+          '   ▪▪     ',
+          '          ',
+          '          '
+        )
+      );
+  });
+
+  it('-135 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-135, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -592,10 +1082,48 @@ describe('Rotate a non-square image', () => {
       );
   });
 
+  it('-180 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-180, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '          ',
+          ' ▴▴▴▴▦▦▦▦ ',
+          ' ▴▴▴▴▦▦▦▦ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          ' ▪▪▪▪▴▴▴▴ ',
+          '          '
+        )
+      );
+  });
+
   it('225 degrees', () => {
     imgSrc
       .clone()
       .rotate(225, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '          ',
+          '   ▴      ',
+          '  ▴▴▴     ',
+          ' ▪▪▴▴▴    ',
+          ' ▪▪▪▴▦▦   ',
+          '  ▪▪▴▦▦▦  ',
+          '   ▴▴▴▦▦▦ ',
+          '    ▴▴▴▦  ',
+          '     ▴▴   ',
+          '          '
+        )
+      );
+  });
+
+  it('-225 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-225, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(
@@ -617,6 +1145,27 @@ describe('Rotate a non-square image', () => {
     imgSrc
       .clone()
       .rotate(315, true)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '          ',
+          '    ▪▪    ',
+          '   ▪▪▪▴   ',
+          '  ▴▪▪▴▴▴  ',
+          ' ▴▴▴▴▴▴   ',
+          '▴▴▴▦▦▴    ',
+          '▴▴▦▦▦     ',
+          ' ▦▦▦      ',
+          '  ▦       ',
+          '          '
+        )
+      );
+  });
+
+  it('-315 degrees ( Anti-Clockwise )', () => {
+    imgSrc
+      .clone()
+      .rotate(-315, true)
       .getJGDSync()
       .should.be.sameJGD(
         mkJGD(


### PR DESCRIPTION
# What's Changing and Why
In the document it says that image rotate is clockwise and it should be!
But the fact is the rotate method is anti-clockwise, So this is fix for the bug & update tests for both clockwise & anti-clock rotate.

for e.g
```js
// This is should rotate the image 90deg clockwise ( to the right ),
// But the fact its being rotated anti-clockwise ( to the left )
image.rotate(90) 
```

The bug caused by the rotation equation, The one is being used is anti-clockwise !
https://en.wikipedia.org/wiki/Rotation_matrix#In_two_dimensions

<img src="https://www.101computing.net/wp/wp-content/uploads/2D-Rotation-Matrix-1.png" > ( Counter-Clockwise )
<img src="https://i.ibb.co/xSk5y1n/2022-10-09-10-41-12.png" > (Clockwise )


## What else might be affected
Nothing but for sure everyone notice this error and made workaround like use negative rotate angle to get clockwise rotate

```js
// Before fix - workaround to rotate image 90 to the right
image.rotate(-90) 
```

So when this fix is applied it should be
```js
// After fix to rotate image 90 to the right
image.rotate(90) 
```



## Tasks

- [x] Add tests
- [ ] Add [SemVer](https://semver.org/) Label ( I couldn't tell if this will be major or minor !, Because it will affect a lot of people who was doing the workaround !  )

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.3-canary.1100.1371.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.16.3-canary.1100.1371.0
  npm install @jimp/core@0.16.3-canary.1100.1371.0
  npm install @jimp/custom@0.16.3-canary.1100.1371.0
  npm install jimp@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-blit@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-blur@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-circle@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-color@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-contain@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-cover@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-crop@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-displace@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-dither@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-fisheye@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-flip@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-gaussian@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-invert@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-mask@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-normalize@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-print@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-resize@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-rotate@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-scale@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-shadow@0.16.3-canary.1100.1371.0
  npm install @jimp/plugin-threshold@0.16.3-canary.1100.1371.0
  npm install @jimp/plugins@0.16.3-canary.1100.1371.0
  npm install @jimp/test-utils@0.16.3-canary.1100.1371.0
  npm install @jimp/bmp@0.16.3-canary.1100.1371.0
  npm install @jimp/gif@0.16.3-canary.1100.1371.0
  npm install @jimp/jpeg@0.16.3-canary.1100.1371.0
  npm install @jimp/png@0.16.3-canary.1100.1371.0
  npm install @jimp/tiff@0.16.3-canary.1100.1371.0
  npm install @jimp/types@0.16.3-canary.1100.1371.0
  npm install @jimp/utils@0.16.3-canary.1100.1371.0
  # or 
  yarn add @jimp/cli@0.16.3-canary.1100.1371.0
  yarn add @jimp/core@0.16.3-canary.1100.1371.0
  yarn add @jimp/custom@0.16.3-canary.1100.1371.0
  yarn add jimp@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-blit@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-blur@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-circle@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-color@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-contain@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-cover@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-crop@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-displace@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-dither@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-fisheye@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-flip@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-gaussian@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-invert@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-mask@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-normalize@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-print@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-resize@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-rotate@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-scale@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-shadow@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugin-threshold@0.16.3-canary.1100.1371.0
  yarn add @jimp/plugins@0.16.3-canary.1100.1371.0
  yarn add @jimp/test-utils@0.16.3-canary.1100.1371.0
  yarn add @jimp/bmp@0.16.3-canary.1100.1371.0
  yarn add @jimp/gif@0.16.3-canary.1100.1371.0
  yarn add @jimp/jpeg@0.16.3-canary.1100.1371.0
  yarn add @jimp/png@0.16.3-canary.1100.1371.0
  yarn add @jimp/tiff@0.16.3-canary.1100.1371.0
  yarn add @jimp/types@0.16.3-canary.1100.1371.0
  yarn add @jimp/utils@0.16.3-canary.1100.1371.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
