### PR TITLE
update jpeg-js

### DIFF
--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "jpeg-js": "^0.4.2"
+    "jpeg-js": "^0.4.4"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7208,6 +7208,11 @@ jpeg-js@^0.4.2:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
   integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
+jpeg-js@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
+  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
+
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
closes #1088

## Release Notes

This release changes the minimum node version from 8 to 16


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.17.0--canary.1131.af3cb94.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @jimp/cli@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/core@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/custom@0.17.0--canary.1131.af3cb94.0
  npm install jimp@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-blit@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-blur@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-circle@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-color@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-contain@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-cover@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-crop@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-displace@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-dither@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-fisheye@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-flip@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-gaussian@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-invert@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-mask@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-normalize@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-print@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-resize@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-rotate@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-scale@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-shadow@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugin-threshold@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/plugins@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/test-utils@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/bmp@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/gif@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/jpeg@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/png@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/tiff@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/types@0.17.0--canary.1131.af3cb94.0
  npm install @jimp/utils@0.17.0--canary.1131.af3cb94.0
  # or 
  yarn add @jimp/cli@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/core@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/custom@0.17.0--canary.1131.af3cb94.0
  yarn add jimp@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-blit@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-blur@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-circle@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-color@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-contain@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-cover@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-crop@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-displace@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-dither@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-fisheye@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-flip@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-gaussian@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-invert@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-mask@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-normalize@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-print@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-resize@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-rotate@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-scale@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-shadow@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugin-threshold@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/plugins@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/test-utils@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/bmp@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/gif@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/jpeg@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/png@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/tiff@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/types@0.17.0--canary.1131.af3cb94.0
  yarn add @jimp/utils@0.17.0--canary.1131.af3cb94.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
