### PR TITLE
remove extra bm-font dep

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,6 @@
     "buffer": "^5.2.0",
     "exif-parser": "^0.1.12",
     "file-type": "^16.5.4",
-    "load-bmfont": "^1.3.1",
     "mkdirp": "^0.5.1",
     "phin": "^2.9.1",
     "pixelmatch": "^4.0.2",

--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "load-bmfont": "^1.4.0"
+    "load-bmfont": "^1.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,14 +1079,14 @@
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@jimp/bmp@link:packages/type-bmp":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     bmp-js "^0.1.0"
 
 "@jimp/core@link:packages/core":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
@@ -1094,20 +1094,19 @@
     buffer "^5.2.0"
     exif-parser "^0.1.12"
     file-type "^16.5.4"
-    load-bmfont "^1.3.1"
     mkdirp "^0.5.1"
     phin "^2.9.1"
     pixelmatch "^4.0.2"
     tinycolor2 "^1.4.1"
 
 "@jimp/custom@link:packages/custom":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/core" "link:packages/core"
 
 "@jimp/gif@link:packages/type-gif":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
@@ -1115,142 +1114,142 @@
     omggif "^1.0.9"
 
 "@jimp/jpeg@link:packages/type-jpeg":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    jpeg-js "^0.4.2"
+    jpeg-js "^0.4.4"
 
 "@jimp/plugin-blit@link:packages/plugin-blit":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-blur@link:packages/plugin-blur":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-circle@link:packages/plugin-circle":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-color@link:packages/plugin-color":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     tinycolor2 "^1.4.1"
 
 "@jimp/plugin-contain@link:packages/plugin-contain":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-cover@link:packages/plugin-cover":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-crop@link:packages/plugin-crop":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-displace@link:packages/plugin-displace":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-dither@link:packages/plugin-dither":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-fisheye@link:packages/plugin-fisheye":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-flip@link:packages/plugin-flip":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-gaussian@link:packages/plugin-gaussian":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-invert@link:packages/plugin-invert":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-mask@link:packages/plugin-mask":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-normalize@link:packages/plugin-normalize":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-print@link:packages/plugin-print":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    load-bmfont "^1.4.0"
+    load-bmfont "^1.4.1"
 
 "@jimp/plugin-resize@link:packages/plugin-resize":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-rotate@link:packages/plugin-rotate":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-scale@link:packages/plugin-scale":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-shadow@link:packages/plugin-shadow":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-threshold@link:packages/plugin-threshold":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugins@link:packages/plugins":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/plugin-blit" "link:packages/plugin-blit"
@@ -1277,26 +1276,26 @@
     timm "^1.6.1"
 
 "@jimp/png@link:packages/type-png":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     pngjs "^3.3.3"
 
 "@jimp/test-utils@link:packages/test-utils":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     pngjs "^3.3.3"
 
 "@jimp/tiff@link:packages/type-tiff":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     utif "^2.0.1"
 
 "@jimp/types@link:packages/types":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/bmp" "link:packages/type-bmp"
@@ -1307,7 +1306,7 @@
     timm "^1.6.1"
 
 "@jimp/utils@link:packages/utils":
-  version "0.16.2"
+  version "0.17.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     regenerator-runtime "^0.13.3"
@@ -7203,11 +7202,6 @@ java-properties@^1.0.0:
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
 
-jpeg-js@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
-  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
-
 jpeg-js@^0.4.4:
   version "0.4.4"
   resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
@@ -7599,21 +7593,10 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-load-bmfont@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.3.1.tgz#0e7933f66543409882127b0d0fbad7a66d5a7869"
-  dependencies:
-    buffer-equal "0.0.1"
-    mime "^1.3.4"
-    parse-bmfont-ascii "^1.0.3"
-    parse-bmfont-binary "^1.0.5"
-    parse-bmfont-xml "^1.1.4"
-    xhr "^2.0.1"
-    xtend "^4.0.0"
-
-load-bmfont@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
+load-bmfont@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz#c0f5f4711a1e2ccff725a7b6078087ccfcddd3e9"
+  integrity sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==
   dependencies:
     buffer-equal "0.0.1"
     mime "^1.3.4"


### PR DESCRIPTION
revives this pr https://github.com/jimp-dev/jimp/pull/1008 and also updates the dep
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.17.1--canary.1134.e007a48.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @jimp/cli@0.17.1--canary.1134.e007a48.0
  npm install @jimp/core@0.17.1--canary.1134.e007a48.0
  npm install @jimp/custom@0.17.1--canary.1134.e007a48.0
  npm install jimp@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-blit@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-blur@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-circle@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-color@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-contain@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-cover@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-crop@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-displace@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-dither@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-fisheye@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-flip@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-gaussian@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-invert@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-mask@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-normalize@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-print@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-resize@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-rotate@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-scale@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-shadow@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugin-threshold@0.17.1--canary.1134.e007a48.0
  npm install @jimp/plugins@0.17.1--canary.1134.e007a48.0
  npm install @jimp/test-utils@0.17.1--canary.1134.e007a48.0
  npm install @jimp/bmp@0.17.1--canary.1134.e007a48.0
  npm install @jimp/gif@0.17.1--canary.1134.e007a48.0
  npm install @jimp/jpeg@0.17.1--canary.1134.e007a48.0
  npm install @jimp/png@0.17.1--canary.1134.e007a48.0
  npm install @jimp/tiff@0.17.1--canary.1134.e007a48.0
  npm install @jimp/types@0.17.1--canary.1134.e007a48.0
  npm install @jimp/utils@0.17.1--canary.1134.e007a48.0
  # or 
  yarn add @jimp/cli@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/core@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/custom@0.17.1--canary.1134.e007a48.0
  yarn add jimp@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-blit@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-blur@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-circle@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-color@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-contain@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-cover@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-crop@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-displace@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-dither@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-fisheye@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-flip@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-gaussian@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-invert@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-mask@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-normalize@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-print@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-resize@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-rotate@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-scale@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-shadow@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugin-threshold@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/plugins@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/test-utils@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/bmp@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/gif@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/jpeg@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/png@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/tiff@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/types@0.17.1--canary.1134.e007a48.0
  yarn add @jimp/utils@0.17.1--canary.1134.e007a48.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
