### PR TITLE
Change some exports to move towards more ESM compatibility

### DIFF
--- a/packages/core/src/modules/phash.js
+++ b/packages/core/src/modules/phash.js
@@ -179,4 +179,4 @@ function applyDCT(f, size) {
   return F;
 }
 
-module.exports = ImagePHash;
+export default ImagePHash;

--- a/packages/plugin-resize/src/modules/resize.js
+++ b/packages/plugin-resize/src/modules/resize.js
@@ -545,4 +545,4 @@ Resize.prototype.generateUint8Buffer = function (bufferLength) {
   }
 };
 
-module.exports = Resize;
+export default Resize;

--- a/packages/plugin-resize/src/modules/resize2.js
+++ b/packages/plugin-resize/src/modules/resize2.js
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-module.exports = {
+const operations = {
   nearestNeighbor(src, dst) {
     const wSrc = src.width;
     const hSrc = src.height;
@@ -291,3 +291,5 @@ module.exports = {
     return this._interpolate2D(src, dst, options, interpolateBezier);
   },
 };
+
+export default operations;


### PR DESCRIPTION
# What's Changing and Why

There's some parts of the source code that still use commonJS export style. This change makes a more consistent code base and once completely done, open opportunities to simplify and improve the compile steps (babel, browserify, etc).

Note: There are still 1 locations with CJS exports, one i being handled in [another PR](https://github.com/jimp-dev/jimp/pull/1153), the other is the [core requests module](https://github.com/jimp-dev/jimp/blob/8c0d0f3b8232d08acac06e9d7bfc5789489c6e1c/packages/core/src/request.js) which requires a larger discussion (PR forthcoming).

## What else might be affected

It's a pretty simple change. The tests run for me and I can't imagine it breaking anything

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
