### PR TITLE
Change test matching strategy to include all test files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": "jimp-dev/jimp",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register test/**/*.js",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": "jimp-dev/jimp",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:browser && npm run build:node:production && npm run build:module",

--- a/packages/plugin-blit/package.json
+++ b/packages/plugin-blit/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-circle/package.json
+++ b/packages/plugin-circle/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-color/package.json
+++ b/packages/plugin-color/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-contain/package.json
+++ b/packages/plugin-contain/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-cover/package.json
+++ b/packages/plugin-cover/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-crop/package.json
+++ b/packages/plugin-crop/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-fisheye/package.json
+++ b/packages/plugin-fisheye/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-flip/package.json
+++ b/packages/plugin-flip/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "build": "npm run build:node:production && npm run build:module",
+    "build": "npm run build:node:production && npm run build:module --recursive test",
     "build:watch": "npm run build:node:debug -- -- --watch --verbose",
     "build:debug": "npm run build:node:debug",
     "build:module": "cross-env BABEL_ENV=module babel src -d es --source-maps --config-file ../../babel.config.js",

--- a/packages/plugin-mask/package.json
+++ b/packages/plugin-mask/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-normalize/package.json
+++ b/packages/plugin-normalize/package.json
@@ -7,7 +7,7 @@
   "types": "index.d.ts",
   "repository": "jimp-dev/jimp",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-resize/package.json
+++ b/packages/plugin-resize/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-rotate/package.json
+++ b/packages/plugin-rotate/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-shadow/package.json
+++ b/packages/plugin-shadow/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/plugin-threshold/package.json
+++ b/packages/plugin-threshold/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -6,7 +6,7 @@
   "repository": "jimp-dev/jimp",
   "module": "es/index.js",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/type-bmp/package.json
+++ b/packages/type-bmp/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/type-gif/babel.config.js
+++ b/packages/type-gif/babel.config.js
@@ -1,0 +1,1 @@
+../../babel.config.js

--- a/packages/type-gif/package.json
+++ b/packages/type-gif/package.json
@@ -7,6 +7,9 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
+    "test:watch": "npm run test -- --reporter min --watch",
+    "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",
     "build:watch": "npm run build:node:debug -- -- --watch --verbose",
     "build:debug": "npm run build:node:debug",
@@ -24,6 +27,10 @@
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"
+  },
+  "devDependencies": {
+    "@jimp/custom": "link:../custom",
+    "@jimp/test-utils": "link:../test-utils"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/type-png/package.json
+++ b/packages/type-png/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",

--- a/packages/type-tiff/package.json
+++ b/packages/type-tiff/package.json
@@ -7,7 +7,7 @@
   "repository": "jimp-dev/jimp",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env BABEL_ENV=test mocha --require @babel/register",
+    "test": "cross-env BABEL_ENV=test mocha --require @babel/register --recursive test  --extension js",
     "test:watch": "npm run test -- --reporter min --watch",
     "test:coverage": "nyc npm run test",
     "build": "npm run build:node:production && npm run build:module",


### PR DESCRIPTION
# What's Changing and Why

I noticed when running tests for `core` that one was missed:

```
> yarn test
yarn run v1.22.19
$ cross-env BABEL_ENV=test mocha --require @babel/register test/**/*.js


  Mime
    getType
      ✓ should return undefined if not found
      ✓ should return the correct mime
    getExtension
      ✓ should return undefined if not found
      ✓ should return the correct extension


  4 passing (26ms)

✨  Done in 0.83s.
```

But there are actually 5 tests. After the change included here:

```
> yarn test
yarn run v1.22.19
$ cross-env BABEL_ENV=test mocha --require @babel/register --recursive test --extension js


  redirect
    ✓ follows 301 redirect

  Mime
    getType
      ✓ should return undefined if not found
      ✓ should return the correct mime
    getExtension
      ✓ should return undefined if not found
      ✓ should return the correct extension


  5 passing (49ms)

✨  Done in 0.95s.
```

I also added a test script for the gif plugin and switched the all test scripts to match tests in a less error prone way.

## What else might be affected

This is only development side. All tests seem to run fine still.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
