### PR TITLE
Fix resizing issue with Jimp.AUTO

### DIFF
--- a/packages/plugin-resize/src/index.js
+++ b/packages/plugin-resize/src/index.js
@@ -48,8 +48,8 @@ export default () => ({
       }
 
       // round inputs
-      w = Math.round(w);
-      h = Math.round(h);
+      w = Math.round(w) || 1;
+      h = Math.round(h) || 1;
 
       if (typeof Resize2[mode] === "function") {
         const dst = {


### PR DESCRIPTION
# What's changing and why?

The change prevents the `width` and `height` to be rounded to `0` when resizing an image with `Jimp.AUTO` as one of the parameters.
See issue #880.

## What else might be affected

--

## Tasks

- [ ] Add tests
- [ ] Update documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) label