### PR TITLE
Export ColorActionName enum

### DIFF
--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -1,4 +1,5 @@
 import * as Jimp from "jimp";
+import { ColorActionName } from "@jimp/plugin-color";
 
 const jimpInst: Jimp = new Jimp("test");
 
@@ -11,6 +12,7 @@ jimpInst.displace(jimpInst, 2);
 jimpInst.shadow((err, val, coords) => {});
 jimpInst.fishEye({ r: 12 });
 jimpInst.circle({ radius: 12, x: 12, y: 12 });
+jimpInst.color([{ apply: ColorActionName.SATURATE, params: [90] }]);
 // $ExpectError
 jimpInst.PNG_FILTER_NONE;
 

--- a/packages/plugin-color/index.d.ts
+++ b/packages/plugin-color/index.d.ts
@@ -1,16 +1,22 @@
 import { ImageCallback } from "@jimp/core";
 
-type ColorActionName =
-  | "mix"
-  | "tint"
-  | "shade"
-  | "xor"
-  | "red"
-  | "green"
-  | "blue"
-  | "hue"
-  | "lighten"
-  | "darken";
+export enum ColorActionName {
+  LIGHTEN = "lighten",
+  BRIGHTEN = "brighten",
+  DARKEN = "darken",
+  DESATURATE = "desaturate",
+  SATURATE = "saturate",
+  GREYSCALE = "greyscale",
+  SPIN = "spin",
+  HUE = "hue",
+  MIX = "mix",
+  TINT = "tint",
+  SHADE = "shade",
+  XOR = "xor",
+  RED = "red",
+  GREEN = "green",
+  BLUE = "blue",
+}
 
 type ColorAction = {
   apply: ColorActionName;

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -128,6 +128,24 @@ function colorFn(actions, cb) {
   return this;
 }
 
+export const ColorActionName = Object.freeze({
+  LIGHTEN: "lighten",
+  BRIGHTEN: "brighten",
+  DARKEN: "darken",
+  DESATURATE: "desaturate",
+  SATURATE: "saturate",
+  GREYSCALE: "greyscale",
+  SPIN: "spin",
+  HUE: "hue",
+  MIX: "mix",
+  TINT: "tint",
+  SHADE: "shade",
+  XOR: "xor",
+  RED: "red",
+  GREEN: "green",
+  BLUE: "blue",
+})
+
 export default () => ({
   /**
    * Adjusts the brightness of the image

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -144,7 +144,7 @@ export const ColorActionName = Object.freeze({
   RED: "red",
   GREEN: "green",
   BLUE: "blue",
-})
+});
 
 export default () => ({
   /**


### PR DESCRIPTION
# What's Changing and Why
This PR fixes #987 by exporting an enum with all possible values for the `color` method's apply parameters. I chose to use an enum because this makes refactoring easier compared to having plain strings. Originally the `ColorActionName` type was missing some values.

## What else might be affected
This is a breaking change for projects using TypeScript because they would have to reference the enum directly and use their values. 

Some possible fix for backwards compatibility (>TS4.1):
```diff
++ type ColorActionNameValue = `${ColorActionName}`

type ColorAction = {
-- apply: ColorActionName;
++ apply: ColorActionName | ColorActionNameValue;
```
If older versions need to be supported I can try to look into it.

## Tasks

- [x] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
