### PR TITLE
chore: upgrade gifwrap

### DIFF
--- a/packages/type-gif/package.json
+++ b/packages/type-gif/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "link:../utils",
-    "gifwrap": "^0.9.2",
+    "gifwrap": "^0.10.1",
     "omggif": "^1.0.9"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,13 +1388,13 @@
     chalk "^4.0.0"
 
 "@jimp/bmp@link:packages/type-bmp":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
     bmp-js "^0.1.0"
 
 "@jimp/core@link:packages/core":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
     any-base "^1.1.0"
@@ -1404,135 +1404,135 @@
     isomorphic-fetch "^3.0.0"
     mkdirp "^2.1.3"
     pixelmatch "^4.0.2"
-    tinycolor2 "^1.4.1"
+    tinycolor2 "^1.6.0"
 
 "@jimp/custom@link:packages/custom":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/core" "link:packages/core"
 
 "@jimp/gif@link:packages/type-gif":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
-    gifwrap "^0.9.2"
+    gifwrap "^0.10.1"
     omggif "^1.0.9"
 
 "@jimp/jpeg@link:packages/type-jpeg":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
     jpeg-js "^0.4.4"
 
 "@jimp/plugin-blit@link:packages/plugin-blit":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-blur@link:packages/plugin-blur":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-circle@link:packages/plugin-circle":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-color@link:packages/plugin-color":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
-    tinycolor2 "^1.4.1"
+    tinycolor2 "^1.6.0"
 
 "@jimp/plugin-contain@link:packages/plugin-contain":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-cover@link:packages/plugin-cover":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-crop@link:packages/plugin-crop":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-displace@link:packages/plugin-displace":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-dither@link:packages/plugin-dither":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-fisheye@link:packages/plugin-fisheye":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-flip@link:packages/plugin-flip":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-gaussian@link:packages/plugin-gaussian":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-invert@link:packages/plugin-invert":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-mask@link:packages/plugin-mask":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-normalize@link:packages/plugin-normalize":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-print@link:packages/plugin-print":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
     load-bmfont "^1.4.1"
 
 "@jimp/plugin-resize@link:packages/plugin-resize":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-rotate@link:packages/plugin-rotate":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-scale@link:packages/plugin-scale":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-shadow@link:packages/plugin-shadow":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-threshold@link:packages/plugin-threshold":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugins@link:packages/plugins":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/plugin-blit" "link:packages/plugin-blit"
     "@jimp/plugin-blur" "link:packages/plugin-blur"
@@ -1558,23 +1558,23 @@
     timm "^1.6.1"
 
 "@jimp/png@link:packages/type-png":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/utils" "link:packages/utils"
     pngjs "^6.0.0"
 
 "@jimp/test-utils@link:packages/test-utils":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     pngjs "^6.0.0"
 
 "@jimp/tiff@link:packages/type-tiff":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     utif2 "^4.0.1"
 
 "@jimp/types@link:packages/types":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     "@jimp/bmp" "link:packages/type-bmp"
     "@jimp/gif" "link:packages/type-gif"
@@ -1584,7 +1584,7 @@
     timm "^1.6.1"
 
 "@jimp/utils@link:packages/utils":
-  version "0.22.0"
+  version "0.22.7"
   dependencies:
     regenerator-runtime "^0.13.3"
 
@@ -2723,6 +2723,11 @@
   version "12.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
   integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
+
+"@types/node@16.9.1":
+  version "16.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
+  integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
 "@types/node@^14.14.35":
   version "14.18.36"
@@ -6122,12 +6127,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gifwrap@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/gifwrap/-/gifwrap-0.9.2.tgz#348e286e67d7cf57942172e1e6f05a71cee78489"
-  integrity sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==
+gifwrap@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/gifwrap/-/gifwrap-0.10.1.tgz#9ed46a5d51913b482d4221ce9c727080260b681e"
+  integrity sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==
   dependencies:
-    image-q "^1.1.1"
+    image-q "^4.0.0"
     omggif "^1.0.10"
 
 git-raw-commits@2.0.0:
@@ -6681,10 +6686,12 @@ ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-image-q@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/image-q/-/image-q-1.1.1.tgz#fc84099664460b90ca862d9300b6bfbbbfbf8056"
-  integrity sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY=
+image-q@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/image-q/-/image-q-4.0.0.tgz#31e075be7bae3c1f42a85c469b4732c358981776"
+  integrity sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==
+  dependencies:
+    "@types/node" "16.9.1"
 
 import-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# What's Changing and Why

I've upgraded the dependency on gifwrap because of this fix https://github.com/jimp-dev/gifwrap/pull/26.

## What else might be affected

It seems to bring an update of `image-q`, I'm not sure if it's important.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
