### PR TITLE
Move docs link into a seperate heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 
 Installation: `npm install --save jimp`
 
+## Documentation
+
 API documentation can be found in the main [jimp package](./packages/jimp)
 
 ## Tools


### PR DESCRIPTION
# What's Changing and Why

The old README is hard to find the document section.

## What else might be affected

N/A

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
