### PR TITLE
Support commonjs default export

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,12 @@ module.exports = (api) => {
     ],
 
     plugins: [
-      process.env.BABEL_ENV !== "module" && "add-module-exports",
+      process.env.BABEL_ENV !== "module" && [
+        "add-module-exports",
+        {
+          addDefaultProperty: true,
+        },
+      ],
       [
         "transform-inline-environment-variables",
         { include: ["BABEL_ENV", "ENV"] },


### PR DESCRIPTION
# What's Changing and Why

Adjusted the **add-module-exports** babel-plugin configuration to create a synthetic default export for CommonJS modules.
In partice, it only appends a `module.exports.default = exports.default;` to every **packages/*/dist/index.js**.

It would be required to support the custom modular configuration of Jimp for CommonJS Typescript projects, where the `esModuleInterop` compiler-option cannot be turned on.

With those settings, the `import Jimp  from 'jimp';` resolves to `const Jimp = require('jimp').default;`.

This will result in a runtime error, as previously the packages didn't have `default` property on their CommonJS export.

For the main distribution of Jimp, this could have been bypassed by using namespace import (`import * as Jimp from 'jimp';`). This is possible as the CommonJS module export for the `jimp` package is an object.
However the namespace importing wouldn't work for the modular packages, as their CommonJS export is a function, which is not supported by the ES6.

## What else might be affected

This change shouldn't have any side-effects, as it is only affecting the method of distribution and is completely additive.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
