### PR TITLE
Fix: rotate resize param on multiples of 90

### DIFF
--- a/packages/plugin-rotate/src/index.js
+++ b/packages/plugin-rotate/src/index.js
@@ -231,8 +231,12 @@ export default () => ({
       return throwError.call(this, "mode must be a boolean or a string", cb);
     }
 
-    if (Math.abs(deg % 90) === 0) {
-      // apply matrixRotate if the angle is a multiple of 90 degrees (eg: 180 or -90)
+    // use matrixRotate if the angle is a multiple of 90 degrees (eg: 180 or -90) and resize is allowed or not needed.
+    const matrixRotateAllowed =
+      deg % 90 === 0 &&
+      (mode || this.bitmap.width === this.bitmap.height || deg % 180 === 0);
+
+    if (matrixRotateAllowed) {
       matrixRotate.call(this, deg);
     } else {
       advancedRotate.call(this, deg, mode, cb);

--- a/packages/plugin-rotate/test/rotation.test.js
+++ b/packages/plugin-rotate/test/rotation.test.js
@@ -567,3 +567,44 @@ describe("Rotate a non-square image", () => {
     );
   });
 });
+
+describe("Rotate a non-square image without resizing", () => {
+  let imgSrc = null;
+  before((done) => {
+    jimp
+      .read(mkJGD("□□□□□□□□", "▹▹▹▹▹▹▹▹", "▿▿▿▿▿▿▿▿", "□□□□□□□□"))
+      .then((imgJimp) => {
+        imgSrc = imgJimp;
+        done();
+      })
+      .catch(done);
+  });
+
+  it("90 degrees", () => {
+    expectToBeJGD(
+      imgSrc.clone().rotate(90, false).getJGDSync(),
+      mkJGD(" □▹▿□   ", " □▹▿□   ", " □▹▿□   ", " □▹▿□   ")
+    );
+  });
+
+  it("180 degrees", () => {
+    expectToBeJGD(
+      imgSrc.clone().rotate(180, false).getJGDSync(),
+      mkJGD("□□□□□□□□", "▿▿▿▿▿▿▿▿", "▹▹▹▹▹▹▹▹", "□□□□□□□□")
+    );
+  });
+
+  it("270 degrees", () => {
+    expectToBeJGD(
+      imgSrc.clone().rotate(270, false).getJGDSync(),
+      mkJGD("  □▿▹□  ", "  □▿▹□  ", "  □▿▹□  ", "  □▿▹□  ")
+    );
+  });
+
+  it("45 degrees", () => {
+    expectToBeJGD(
+      imgSrc.clone().rotate(45, false).getJGDSync(),
+      mkJGD(" □▹▹▿□□ ", "□▹▹▿□□  ", "▹▹▿□□   ", "▹▿□□    ")
+    );
+  });
+});


### PR DESCRIPTION
# What's Changing and Why
Before https://github.com/jimp-dev/jimp/pull/1209 specifying resize=false with `rotate()` would never resize the image, however the new matrix rotation algo will always resize the image regardless of this parameter. This PR introcudes some more checks to see if matrix rotation can be used and otherwise falls back to using `advancedRotate`

## What else might be affected
Shouldn't affect anything, fixes incorrect behavior.

## Tasks

- [X] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
