### PR TITLE
avoid relying on __dirname global constant

### DIFF
--- a/packages/plugin-print/src/index.js
+++ b/packages/plugin-print/src/index.js
@@ -1,7 +1,11 @@
 import Path from "path";
+import Url from 'url';
 import bMFont from "load-bmfont";
 import { isNodePattern, throwError } from "@jimp/utils";
 import { measureText, measureTextHeight, splitLines } from "./measure-text";
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = Path.dirname(__filename);
 
 function xOffsetBasedOnAlignment(constants, font, line, maxWidth, alignment) {
   if (alignment === constants.HORIZONTAL_ALIGN_LEFT) {


### PR DESCRIPTION
Fixes #1235

# What's Changing and Why
Removed usage of global variable `__dirname` to avoid errors when bundling with rollup

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
