### PR TITLE
Encoder for GIF provides a Promise to getBuffer when a string, Buffer, or Uint8Array is expected

### DIFF
--- a/packages/core/src/utils/image-bitmap.js
+++ b/packages/core/src/utils/image-bitmap.js
@@ -225,7 +225,15 @@ export function getBuffer(mime, cb) {
 
   if (this.constructor.encoders[mime]) {
     const buffer = this.constructor.encoders[mime](this);
-    cb.call(this, null, buffer);
+    //Typically, buffers return a string or map.  However, the gif library "gifwrap" seemingly returns promises.
+    if(buffer instanceof Promise){
+      //trigger the callback when the promise has been resolved
+      buffer.then((buff) => {
+        cb.call(this, null, buff);
+      })
+    } else {
+      cb.call(this, null, buffer);
+    }
   } else {
     return throwError.call(this, "Unsupported MIME type: " + mime, cb);
   }

--- a/packages/core/src/utils/image-bitmap.js
+++ b/packages/core/src/utils/image-bitmap.js
@@ -225,12 +225,12 @@ export function getBuffer(mime, cb) {
 
   if (this.constructor.encoders[mime]) {
     const buffer = this.constructor.encoders[mime](this);
-    //Typically, buffers return a string or map.  However, the gif library "gifwrap" seemingly returns promises.
-    if(buffer instanceof Promise){
-      //trigger the callback when the promise has been resolved
+    // Typically, buffers return a string or map.  However, the gif library "gifwrap" seemingly returns promises.
+    if (buffer instanceof Promise) {
+      // trigger the callback when the promise has been resolved
       buffer.then((buff) => {
         cb.call(this, null, buff);
-      })
+      });
     } else {
       cb.call(this, null, buffer);
     }


### PR DESCRIPTION
Fixing Issue 980: The 'chunk' argument must be of type string or an Instance of Buffer or Uint8Array. Received an instance of Promise.

# What's Changing and Why
On jimp/packages/core/src/utils/image-bitmap.js getBuffer(mime, cb) function, the method is intended to provide a string or a buffer to a callback function so that the callback can consume such buffer (typically with the Write function).

However, occasionally the following error will occur ( see also #980 ):

```
internal/streams/writable.js:285
      throw new ERR_INVALID_ARG_TYPE(
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Promise
    at new NodeError (internal/errors.js:322:7)
    at WriteStream.Writable.write (internal/streams/writable.js:285:13)
    at WriteStream.<anonymous> (/home/zachs1590/cs464-jimp-testing/node_modules/@jimp/core/dist/index.js:462:16)
    at WriteStream.emit (events.js:400:28)
    at internal/fs/streams.js:340:12
    at FSReqCallback.oncomplete (fs.js:180:23) {
  code: 'ERR_INVALID_ARG_TYPE'
```

I traced the issue back to the fact that one of the encoders, the GIF encoder, consistently returns a promise rather than a string or a buffer response.  See jimp/packages/type-gif/src/index.js line 34.

Rather than solve this issue at the GIF encoder (if that could be solved at all), it seemed like a better idea to make the get buffer function more robust by permitting encoders to return a promise as a valid data type and handle such a response gracefully.

Accordingly, on jimp/packages/core/src/utils/image-bitmap.js getBuffer(mime, cb), I have added

```js
  if (this.constructor.encoders[mime]) {
    const buffer = this.constructor.encoders[mime](this);
    //Typically, buffers return a string or map.  However, the gif library "gifwrap" seemingly returns promises.
    if(buffer instanceof Promise){
      //trigger the callback when the promise has been resolved
      buffer.then((buff) => {
        cb.call(this, null, buff);
      })
    } else {
      cb.call(this, null, buffer);
    }
```
## What else might be affected
n/a