### PR TITLE
fix: Remove dependency on mkdirp

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,6 @@
     "exif-parser": "^0.1.12",
     "file-type": "^16.5.4",
     "isomorphic-fetch": "^3.0.0",
-    "mkdirp": "^2.1.3",
     "pixelmatch": "^4.0.2",
     "tinycolor2": "^1.6.0"
   },

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -4,7 +4,6 @@ import EventEmitter from "events";
 
 import { isNodePattern, throwError, scan, scanIterator } from "@jimp/utils";
 import anyBase from "any-base";
-import mkdirp from "mkdirp";
 import pixelMatch from "pixelmatch";
 import tinyColor from "tinycolor2";
 
@@ -522,7 +521,7 @@ class Jimp extends EventEmitter {
     const pathObj = Path.parse(path);
 
     if (pathObj.dir) {
-      mkdirp.sync(pathObj.dir);
+      fs.mkdirSync(pathObj.dir, { recursive: true });
     }
 
     this.getBuffer(mime, (err, buffer) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8423,11 +8423,6 @@ mkdirp@^1.0.3:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz#b083ff37be046fd3d6552468c1f0ff44c1545d1f"
-  integrity sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==
-
 mocha@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.0.tgz#f896b642843445d1bb8bca60eabd9206b8916e56"


### PR DESCRIPTION
This dependency does not work in a browser. Node 10+ includes the recursive parameter for mkdirSync
