### PR TITLE
Update webpack config to output UMD library

### DIFF
--- a/packages/jimp/webpack.config.ts
+++ b/packages/jimp/webpack.config.ts
@@ -34,5 +34,10 @@ export default {
   output: {
     path: path.join(__dirname, "browser/lib"),
     filename: "jimp.js",
+    library: {
+      name: "Jimp",
+      type: "umd",
+      export: "default",
+    }
   },
 } as webpack.Configuration;


### PR DESCRIPTION
# What's Changing and Why
This addresses an issue when importing Jimp in a browser environment (detailed issue with workarounds here: https://github.com/jimp-dev/jimp/issues/1194):

```typescript
import Jimp from 'jimp';
// Jimp = {}

const Jimp = require('jimp');
// Jimp = {}

// Workaround:
import type TJimp from 'jimp';
import 'jimp';

const { Jimp } = window as unknown as { Jimp: typeof TJimp };
```

The proposed fix correctly configures webpack to emit a library export, which both fixes the issue above as well as maintains compatibility with current import methods (and workarounds).