### PR TITLE
Add additional parameter to `sepia` effect to control its intensity

### DIFF
--- a/packages/jimp/test/callbacks.test.js
+++ b/packages/jimp/test/callbacks.test.js
@@ -77,7 +77,7 @@ describe("Callbacks", () => {
       },
     },
     sepia: {
-      args: [],
+      args: [1],
       result: {
         width: 3,
         height: 3,

--- a/packages/plugin-color/README.md
+++ b/packages/plugin-color/README.md
@@ -134,7 +134,7 @@ main();
 
 ## sepia
 
-Applies a sepia tone to the image
+Applies a sepia tone to the image with given intensity, a factor between 0 and 1
 
 - @param {function(Error, Jimp)} cb (optional) a callback for when complete
 
@@ -144,7 +144,7 @@ import jimp from "jimp";
 async function main() {
   const image = await jimp.read("test/image.png");
 
-  image.sepia();
+  image.sepia(1);
 }
 
 main();

--- a/packages/plugin-color/index.d.ts
+++ b/packages/plugin-color/index.d.ts
@@ -30,7 +30,7 @@ interface Color {
   greyscale(cb?: ImageCallback<this>): this;
   grayscale(cb?: ImageCallback<this>): this;
   opacity(f: number, cb?: ImageCallback<this>): this;
-  sepia(f: number, cb?: ImageCallback<this>): this;
+  sepia(f?: number, cb?: ImageCallback<this>): this;
   fade(f: number, cb?: ImageCallback<this>): this;
   convolution(kernel: number[][], cb?: ImageCallback<this>): this;
   convolution<T>(

--- a/packages/plugin-color/index.d.ts
+++ b/packages/plugin-color/index.d.ts
@@ -30,7 +30,7 @@ interface Color {
   greyscale(cb?: ImageCallback<this>): this;
   grayscale(cb?: ImageCallback<this>): this;
   opacity(f: number, cb?: ImageCallback<this>): this;
-  sepia(cb?: ImageCallback<this>): this;
+  sepia(f: number, cb?: ImageCallback<this>): this;
   fade(f: number, cb?: ImageCallback<this>): this;
   convolution(kernel: number[][], cb?: ImageCallback<this>): this;
   convolution<T>(

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -321,7 +321,7 @@ export default () => ({
    * @param {function(Error, Jimp)} cb (optional) a callback for when complete
    * @returns {Jimp }this for chaining of methods
    */
-  sepia(f, cb) {
+  sepia(f = 1, cb) {
     if (typeof f !== "number")
       return throwError.call(this, "f must be a number", cb);
     if (f < 0 || f > 1)

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -321,7 +321,12 @@ export default () => ({
    * @param {function(Error, Jimp)} cb (optional) a callback for when complete
    * @returns {Jimp }this for chaining of methods
    */
-  sepia(cb) {
+  sepia(f, cb) {
+    if (typeof f !== "number")
+      return throwError.call(this, "f must be a number", cb);
+    if (f < 0 || f > 1)
+      return throwError.call(this, "f must be a number from 0 to 1", cb);
+
     this.scanQuiet(
       0,
       0,
@@ -332,9 +337,9 @@ export default () => ({
         let green = this.bitmap.data[idx + 1];
         let blue = this.bitmap.data[idx + 2];
 
-        red = red * 0.393 + green * 0.769 + blue * 0.189;
-        green = red * 0.349 + green * 0.686 + blue * 0.168;
-        blue = red * 0.272 + green * 0.534 + blue * 0.131;
+        red = red * (1 - 0.607 * f) + green * 0.769 * f + blue * 0.189 * f;
+        green = red * 0.349 * f + green * (1 - 0.314 * f) + blue * 0.168 * f;
+        blue = red * 0.272 * f + green * 0.534 * f + blue * (1 - 0.869 * f);
 
         this.bitmap.data[idx] = red < 255 ? red : 255;
         this.bitmap.data[idx + 1] = green < 255 ? green : 255;


### PR DESCRIPTION
# What's Changing and Why

This will add an additional parameter to the `sepia` effect to control its intensity.
Useful for implementing some Instagram-like filters via Jimp.

## What else might be affected

Nothing, still works as expected if you call, as the `f` parameter is optional.

## Tasks

- [x] Add tests
- [x] Update Documentation
- [x] Update `jimp.d.ts`
- [] Add [SemVer](https://semver.org/) Label
