### PR TITLE
Improve color operations performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     src="https://s3.amazonaws.com/pix.iemoji.com/images/emoji/apple/ios-11/256/crayon.png">
   <h1>Jimp</h1>
   <p>JavaScript Image Manipulation Program</p>
-  <p>An image processing library for Node written entirely in JavaScript, with zero native dependencies.</p>
+  <p>An image processing library for Node written entirely in JavaScript, with zero native dependencies</p>
 </div>
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -905,16 +905,13 @@ Jimp.rgbaToInt = function (r, g, b, a, cb) {
     return throwError.call(this, "a must be between 0 and 255", cb);
   }
 
-  r = Math.round(r);
-  b = Math.round(b);
-  g = Math.round(g);
-  a = Math.round(a);
-
-  const i =
-    r * Math.pow(256, 3) +
-    g * Math.pow(256, 2) +
-    b * Math.pow(256, 1) +
-    a * Math.pow(256, 0);
+  let i = (r & 0xff);
+  i <<= 8;
+  i |= (g & 0xff)
+  i <<= 8;
+  i |= (b & 0xff)
+  i <<= 8;
+  i |= (a & 0xff);
 
   if (isNodePattern(cb)) {
     cb.call(this, null, i);

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -901,6 +901,8 @@ Jimp.rgbaToInt = function (r, g, b, a, cb) {
   i <<= 8;
   i |= (b & 0xff)
   i <<= 8;
+  // Ensure sign is correct
+  i >>>= 0;
   i |= (a & 0xff);
 
   if (isNodePattern(cb)) {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -792,14 +792,12 @@ class Jimp extends EventEmitter {
    * @return {boolean} hasAlpha whether the image contains opaque pixels
    */
   hasAlpha() {
-    for (let yIndex = 0; yIndex < this.bitmap.height; yIndex++) {
-      for (let xIndex = 0; xIndex < this.bitmap.width; xIndex++) {
-        const idx = (this.bitmap.width * yIndex + xIndex) << 2;
-        const alpha = this.bitmap.data[idx + 3];
+    const {width, height, data} = this.bitmap;
+    const byteLen = (width * height) << 2;
 
-        if (alpha !== 0xff) {
-          return true;
-        }
+    for (let idx = 3; idx < byteLen; idx += 4) {
+      if (data[idx] !== 0xff) {
+        return true;
       }
     }
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -901,9 +901,10 @@ Jimp.rgbaToInt = function (r, g, b, a, cb) {
   i <<= 8;
   i |= (b & 0xff)
   i <<= 8;
+  i |= (a & 0xff);
+
   // Ensure sign is correct
   i >>>= 0;
-  i |= (a & 0xff);
 
   if (isNodePattern(cb)) {
     cb.call(this, null, i);

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -739,10 +739,6 @@ class Jimp extends EventEmitter {
     if (typeof x !== "number" || typeof y !== "number")
       return throwError.call(this, "x and y must be numbers", cb);
 
-    // round input
-    x = Math.round(x);
-    y = Math.round(y);
-
     const idx = this.getPixelIndex(x, y);
     const hex = this.bitmap.data.readUInt32BE(idx);
 
@@ -770,10 +766,6 @@ class Jimp extends EventEmitter {
       typeof y !== "number"
     )
       return throwError.call(this, "hex, x and y must be numbers", cb);
-
-    // round input
-    x = Math.round(x);
-    y = Math.round(y);
 
     const idx = this.getPixelIndex(x, y);
     this.bitmap.data.writeUInt32BE(hex, idx);

--- a/packages/core/src/modules/phash.js
+++ b/packages/core/src/modules/phash.js
@@ -130,11 +130,11 @@ ImagePHash.prototype.getHash = function (img) {
  */
 function intToRGBA(i) {
   const a = i & 0xff;
-  i >>= 8;
+  i >>>= 8;
   const b = i & 0xff;
-  i >>= 8;
+  i >>>= 8;
   const g = i & 0xff;
-  i >>= 8;
+  i >>>= 8;
   const r = i & 0xff;
 
   return {r, g, b, a};

--- a/packages/core/src/modules/phash.js
+++ b/packages/core/src/modules/phash.js
@@ -125,24 +125,19 @@ ImagePHash.prototype.getHash = function (img) {
 
 // DCT function stolen from http://stackoverflow.com/questions/4240490/problems-with-dct-and-idct-algorithm-in-java
 
+/**
+ Convert a 32-bit integer color value to an RGBA object.
+ */
 function intToRGBA(i) {
-  const rgba = {};
+  const a = i & 0xff;
+  i >>= 8;
+  const b = i & 0xff;
+  i >>= 8;
+  const g = i & 0xff;
+  i >>= 8;
+  const r = i & 0xff;
 
-  rgba.r = Math.floor(i / Math.pow(256, 3));
-  rgba.g = Math.floor((i - rgba.r * Math.pow(256, 3)) / Math.pow(256, 2));
-  rgba.b = Math.floor(
-    (i - rgba.r * Math.pow(256, 3) - rgba.g * Math.pow(256, 2)) /
-      Math.pow(256, 1)
-  );
-  rgba.a = Math.floor(
-    (i -
-      rgba.r * Math.pow(256, 3) -
-      rgba.g * Math.pow(256, 2) -
-      rgba.b * Math.pow(256, 1)) /
-      Math.pow(256, 0)
-  );
-
-  return rgba;
+  return {r, g, b, a};
 }
 
 const c = [];


### PR DESCRIPTION
# What's Changing and Why

Some functions have operations within loops that don't need to be and/or use floating point math where bitwise operators are faster.  Performance is impacted when doing intense operations on large images.

## What else might be affected

Nothing.  The logic is exactly equivalent.

## Tasks

None required - changes are entirely internal.
