### PR TITLE
Jimp.diff() to make real resize before image compare

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -983,16 +983,16 @@ Jimp.diff = function (img1, img2, threshold = 0.1) {
   if (!(img1 instanceof Jimp) || !(img2 instanceof Jimp))
     return throwError.call(this, "img1 and img2 must be an Jimp images");
 
-  const bmp1 = img1.bitmap;
-  const bmp2 = img2.bitmap;
+  let bmp1 = img1.bitmap;
+  let bmp2 = img2.bitmap;
 
   if (bmp1.width !== bmp2.width || bmp1.height !== bmp2.height) {
     if (bmp1.width * bmp1.height > bmp2.width * bmp2.height) {
       // img1 is bigger
-      img1 = img1.cloneQuiet().resize(bmp2.width, bmp2.height);
+      bmp1 = img1.cloneQuiet().resize(bmp2.width, bmp2.height).bitmap;
     } else {
       // img2 is bigger (or they are the same in area)
-      img2 = img2.cloneQuiet().resize(bmp1.width, bmp1.height);
+      bmp2 = img2.cloneQuiet().resize(bmp1.width, bmp1.height).bitmap;
     }
   }
 


### PR DESCRIPTION
Order of images passed to Jimp.diff() affected the result
```    
    const diff1 = Jimp.diff(await Jimp.read('img1.jpg'), await Jimp.read('img2.jpg'));
    console.log('diff 1', diff1.percent);
    const diff2 = Jimp.diff(await Jimp.read('img2.jpg'), await Jimp.read('img1.jpg'));
    console.log('diff 2', diff2.percent);
```
Results were
```
diff 1 0.5332172192928611
diff 2 0.026531444444444444
```

This happened because compare happened for non resized images
I fixed resizing of images, so now we compare images of same sizes

After changes in this pull requests results are
```
diff 1 0.11355172316561868
diff 2 0.11355172316561868
```

