### PR TITLE
Update EventEmitter import for es module compatibility

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import Path from "path";
-import EventEmitter from "events";
+import * as EventEmitter from "events";
 
 import { isNodePattern, throwError, scan, scanIterator } from "@jimp/utils";
 import anyBase from "any-base";


### PR DESCRIPTION
# What's Changing and Why

Changed the `packages/core/src/index.js` import of the `EventEmitter` class.

Was: `import EventEmitter from "events"`

Now: `import * as EventEmitter from "events"`

This change was required for building a project utilizing Jimp custom to build a slimmer version of the library. The project is built as a module with target `esnext` on Node20 and Typescript using Vite. 
Without this fix, `vite build` will produce the following error:
```
error during build:
RollupError: node_modules/@jimp/core/es/index.js (29:7): "default" is not exported by "node_modules/events/events.js", imported by "node_modules/@jimp/core/es/index.js".
file: [...]/node_modules/@jimp/core/es/index.js:29:7
```


The `events` package is not an es module yet, see [Issue 86](https://github.com/browserify/events/issues/86) and converting it to one is not on the roadmap as far as I can tell. Therefore, this fix should be applied to Jimp directly.

## What else might be affected

Compatibility may be affected when building Jimp not as an es module.

## Tasks

- [ ] Add [SemVer](https://semver.org/) Label
