### PR TITLE
fix: handle uint8array in node

### DIFF
--- a/packages/core/test/array-buffer.js
+++ b/packages/core/test/array-buffer.js
@@ -1,0 +1,13 @@
+import expect from "@storybook/expect";
+import { isArrayBuffer } from "..";
+
+describe("isArrayBuffer", () => {
+  it("true", () => {
+    expect(isArrayBuffer(new ArrayBuffer(2))).toEqual(true);
+    expect(isArrayBuffer(new Uint8Array(2))).toEqual(true);
+  });
+
+  it("false", () => {
+    expect(isArrayBuffer(new Buffer(2))).toEqual(true);
+  });
+});


### PR DESCRIPTION
# What's Changing and Why

It handles properly when Jimp receives a Uint8array buffer.

Since [puppeteer@23](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.0.0), Uint8Array is used instead of of Buffer. This is the default way for serializing a screenshot or pdf:

```js
const buffer = await page.screenshot(opts) // this is a Uint8array now!
```

I noted Jimp was already handling arrayBuffer → buffer mainly targeting browsers, but now that Node.js is trying to move away from buffer I extended the original implementation to handle these case in Nodeland too.

Additionally, could be nice if Jimp supports native Uint8array manipulation so it doesn't need to turn it into Buffer.

## What else might be affected

Nothing else!

## Tasks

- [x] Add tests
- [x] Update Documentation (nothing to do)
- [x] Update `jimp.d.ts` (nothing to do)
- [ ] Add [SemVer](https://semver.org/) Label (I can't add labels)
