### PR TITLE
add missing dependency

### DIFF
--- a/plugins/plugin-hash/package.json
+++ b/plugins/plugin-hash/package.json
@@ -17,6 +17,7 @@
     "@jimp/config-typescript": "workspace:*",
     "@jimp/config-vitest": "workspace:*",
     "@jimp/test-utils": "workspace:*",
+    "@types/any-base": "^1.1.3",
     "@vitest/browser": "^1.4.0",
     "eslint": "^8.57.0",
     "tshy": "^1.12.0",
@@ -34,7 +35,6 @@
     "@jimp/plugin-resize": "workspace:*",
     "@jimp/types": "workspace:*",
     "@jimp/utils": "workspace:*",
-    "@types/any-base": "^1.1.3",
     "any-base": "^1.1.0"
   },
   "tshy": {

--- a/plugins/plugin-hash/package.json
+++ b/plugins/plugin-hash/package.json
@@ -18,7 +18,6 @@
     "@jimp/config-vitest": "workspace:*",
     "@jimp/test-utils": "workspace:*",
     "@vitest/browser": "^1.4.0",
-    "any-base": "^1.1.0",
     "eslint": "^8.57.0",
     "tshy": "^1.12.0",
     "typescript": "^5.5.4",
@@ -35,7 +34,8 @@
     "@jimp/plugin-resize": "workspace:*",
     "@jimp/types": "workspace:*",
     "@jimp/utils": "workspace:*",
-    "@types/any-base": "^1.1.3"
+    "@types/any-base": "^1.1.3",
+    "any-base": "^1.1.0"
   },
   "tshy": {
     "exclude": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1267,9 +1267,6 @@ importers:
       '@jimp/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      '@types/any-base':
-        specifier: ^1.1.3
-        version: 1.1.3
       any-base:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1286,6 +1283,9 @@ importers:
       '@jimp/test-utils':
         specifier: workspace:*
         version: link:../../packages/test-utils
+      '@types/any-base':
+        specifier: ^1.1.3
+        version: 1.1.3
       '@vitest/browser':
         specifier: ^1.4.0
         version: 1.4.0(playwright@1.42.1)(vitest@1.4.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1270,6 +1270,9 @@ importers:
       '@types/any-base':
         specifier: ^1.1.3
         version: 1.1.3
+      any-base:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@jimp/config-eslint':
         specifier: workspace:*
@@ -1286,9 +1289,6 @@ importers:
       '@vitest/browser':
         specifier: ^1.4.0
         version: 1.4.0(playwright@1.42.1)(vitest@1.4.0)
-      any-base:
-        specifier: ^1.1.0
-        version: 1.1.0
       eslint:
         specifier: ^8.57.0
         version: 8.57.0


### PR DESCRIPTION
# What's Changing and Why

Trying to use 1.0.4, I got:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'any-base' imported from node_modules/.pnpm/@jimp+plugin-hash@1.0.4/node_modules/@jimp/plugin-hash/dist/esm/index.js
```

Was this supposed to be bundled? Otherwise I think it needs to be listed in the `dependencies`

## What else might be affected

N/A

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
