### PR TITLE
Fix using dirname in print plugin

### DIFF
--- a/plugins/plugin-print/package.json
+++ b/plugins/plugin-print/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "vitest",
-    "build": "tshy",
+    "build": "tshy && cp -r fonts dist",
     "dev": "tshy --watch",
     "clean": "rm -rf node_modules .tshy .tshy-build dist .turbo"
   },

--- a/plugins/plugin-print/src/dirname-cjs.cts
+++ b/plugins/plugin-print/src/dirname-cjs.cts
@@ -1,0 +1,1 @@
+export const dirname = __dirname;

--- a/plugins/plugin-print/src/dirname.ts
+++ b/plugins/plugin-print/src/dirname.ts
@@ -1,0 +1,6 @@
+import { fileURLToPath } from "url";
+import path from "path";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore Dual package
+export const dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/plugins/plugin-print/src/fonts.ts
+++ b/plugins/plugin-print/src/fonts.ts
@@ -1,6 +1,7 @@
 import path from "path";
+import { dirname } from "./dirname.js";
 
-const dir = path.join(__dirname, "../");
+const dir = path.join(dirname, "../");
 
 export const SANS_8_BLACK = path.join(
   dir,


### PR DESCRIPTION
This is the last place in non-test code that __dirname is used. After this esm usage of all apis should be good.