### PR TITLE
Pass decoder options to the underlying decoder when reading from files and buffers, not just URLs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,11 +228,11 @@ export function createJimp<
       options?: MimeTypeToDecodeOptions
     ) {
       if (Buffer.isBuffer(url) || url instanceof ArrayBuffer) {
-        return this.fromBuffer(url);
+        return this.fromBuffer(url, options);
       }
 
       if (existsSync(url)) {
-        return this.fromBuffer(await readFile(url));
+        return this.fromBuffer(await readFile(url), options);
       }
 
       const [fetchErr, response] = await to(fetch(url));


### PR DESCRIPTION
# What's Changing and Why

This should fix https://github.com/jimp-dev/jimp/issues/1356

This ensures that decoder options are passed regardless of where Jimp reads an image from. Right now, the options are only passed if Jimp reads an image from a URL, but not when it reads it from a file or from a buffer. 

Without this, it is sometimes impossible to read large JPEG files (~8k resolution) from files or buffers, as reading a large JPEG can fail with a memory allocation error unless a high enough `maxMemoryUsageInMB` value is passed to the `js-jpeg` decoder (by default its memory usage is limited to only 512 MB).

## What else might be affected

Hopefully nothing.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
