### PR TITLE
docs: fix resize examples to follow ResizeOptionsSchema

### DIFF
--- a/packages/docs/src/content/docs/guides/custom-jimp.mdx
+++ b/packages/docs/src/content/docs/guides/custom-jimp.mdx
@@ -23,7 +23,7 @@ const MyJimp = createJimp({
 
 const image = await MyJimp.read("test/image.png");
 
-image.resize({ width: 100 });
+image.resize({ w: 100 });
 
 await image.write("test/output.png");
 ```

--- a/packages/docs/src/content/docs/guides/getting-started.mdx
+++ b/packages/docs/src/content/docs/guides/getting-started.mdx
@@ -46,7 +46,7 @@ The workflow for using jimp
 2. Manipulate the image.
 
    ```ts
-   image.resize({ width: 100 });
+   image.resize({ w: 100 });
    ```
 
 3. Save the image.

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ Load an image, manipulate it, and save it.
 2. Manipulate the image.
 
    ```ts
-   image.resize({ width: 100 });
+   image.resize({ w: 100 });
    ```
 
 3. Save the image.

--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -35,7 +35,7 @@ const { Jimp } = require("jimp");
 // open a file called "lenna.png"
 const image = await Jimp.read("test.png");
 
-image.resize(256, 256); // resize
+image.resize({w: 256, h: 256}); // resize
 
 await image.write("test-small.jpg"); // save
 ```


### PR DESCRIPTION
# What's Changing and Why

The docs were updated cause the resize function should receive an object following the **"ResizeOptionsSchema"**, as in Jimp@1.6.0

## What else might be affected

Nothing really :P

## Tasks

- [ ] Update Documentation
