### PR TITLE
Fix isWebWorker check

### DIFF
--- a/plugins/plugin-print/src/load-bitmap-font.ts
+++ b/plugins/plugin-print/src/load-bitmap-font.ts
@@ -10,7 +10,7 @@ import xmlPackage from "simple-xml-to-json";
 const { convertXML } = xmlPackage;
 
 export const isWebWorker =
-  typeof self !== "undefined" && self.document === undefined;
+  typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
 
 const CharacterJimp = createJimp({ formats: [png] });
 const HEADER = Buffer.from([66, 77, 70, 3]);


### PR DESCRIPTION
The problem here is that there is a false positive on Cloudflare Workers that makes jimp think that it is running in a WebWorker, which makes it fail on loading fonts.

This PR fix that, one step beyond to a better support for CF Workers.

Ref: https://stackoverflow.com/questions/7931182/reliably-detect-if-the-script-is-executing-in-a-web-worker

Related https://github.com/jimp-dev/jimp/issues/1358