### PR TITLE
fix: small typo in doc

### DIFF
--- a/packages/docs/src/content/docs/guides/migrate-to-v1.mdx
+++ b/packages/docs/src/content/docs/guides/migrate-to-v1.mdx
@@ -67,7 +67,7 @@ const image = new Jimp({ width: 100, height: 100, color: 0xff0000ff });
 ### `Jimp.read`
 
 In v0 of jimp the constructor was async!
-This is a huge anit-pattern so it had to go.
+This is a huge anti-pattern so it had to go.
 
 Now you should instead use the `Jimp.read` method.
 


### PR DESCRIPTION
# What's Changing and Why

Fix a small typo in migrating docs

## What else might be affected

Nil

## Tasks

- [ ] Add tests
- [x] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
