### PR TITLE
fix: resolve dev build failures and docs import issues

### DIFF
--- a/packages/config-vitest/package.json
+++ b/packages/config-vitest/package.json
@@ -7,7 +7,6 @@
     "node": ">=18"
   },
   "scripts": {
-    "dev": "tshy --watch",
     "clean": "rm -rf node_modules .tshy .tshy-build dist .turbo"
   },
   "author": "Andrew Lisowski <lisowski54@gmail.com>",

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from "@astrojs/starlight";
 import starlightTypeDoc, { typeDocSidebarGroup } from "starlight-typedoc";
 import react from "@astrojs/react";
 import path from "path";
+import { fileURLToPath } from "url";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 export default defineConfig({
@@ -42,12 +43,12 @@ export default defineConfig({
             sort: ["static-first", "alphabetical"],
             plugin: [
               path.join(
-                path.dirname(import.meta.url).replace("file:", ""),
+                path.dirname(fileURLToPath(import.meta.url)),
                 "./src/typedoc-plugin.js"
               ),
               "typedoc-plugin-zod",
               path.join(
-                path.dirname(import.meta.url).replace("file:", ""),
+                path.dirname(fileURLToPath(import.meta.url)),
                 "./src/typedoc-zod-extended.js"
               ),
             ],
@@ -58,5 +59,10 @@ export default defineConfig({
   ],
   vite: {
     plugins: [nodePolyfills({ include: ["buffer"] })],
+    resolve: {
+      alias: {
+        "jimp": path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../jimp/dist/esm/index.js"),
+      },
+    },
   },
 });


### PR DESCRIPTION
- Remove unnecessary dev script from @jimp/config-vitest package
- Fix TypeDoc plugin path resolution using fileURLToPath
- Add Vite alias to resolve jimp imports to ESM build in docs

Fixes development environment setup issues including:
- @jimp/config-vitest#dev command failure due to missing TypeScript source files
- TypeDoc plugin loading errors on Windows due to URL encoding in paths
- React component import errors in documentation due to incomplete browser build

# What's Changing and Why

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
