### PR TITLE
Replace tinycolor2 with @colordx/core

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,14 +15,13 @@
   "author": "Andrew Lisowski <lisowski54@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@jimp/types": "workspace:*",
-    "tinycolor2": "^1.6.0"
+    "@colordx/core": "^6.3.0",
+    "@jimp/types": "workspace:*"
   },
   "devDependencies": {
     "@jimp/config-eslint": "workspace:*",
     "@jimp/config-typescript": "workspace:*",
     "@types/node": "^18.19.48",
-    "@types/tinycolor2": "^1.4.6",
     "eslint": "^9.9.1",
     "tshy": "^3.0.2",
     "typescript": "^5.5.4",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,11 @@
 import { RGBAColor, JimpClass, Bitmap, RGBColor } from "@jimp/types";
-import tinyColor from "tinycolor2";
+import { Colordx, extend } from "@colordx/core";
+import names from "@colordx/core/plugins/names";
+import hsv from "@colordx/core/plugins/hsv";
+
+extend([names, hsv]);
+
+const BARE_HEX = /^(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
 export function clone<I extends JimpClass>(image: I): I {
   const newBitmap = {
@@ -267,5 +273,9 @@ export function cssColorToHex(cssColor: string | number) {
     return cssColor;
   }
 
-  return parseInt(tinyColor(cssColor).toHex8(), 16);
+  const trimmed = cssColor.trim();
+
+  return new Colordx(
+    BARE_HEX.test(trimmed) ? `#${trimmed}` : cssColor
+  ).toNumber32();
 }

--- a/plugins/plugin-color/package.json
+++ b/plugins/plugin-color/package.json
@@ -23,7 +23,6 @@
     "@jimp/js-png": "workspace:*",
     "@jimp/test-utils": "workspace:*",
     "@types/node": "^18.19.48",
-    "@types/tinycolor2": "^1.4.6",
     "@vitest/browser": "^2.0.5",
     "eslint": "^9.9.1",
     "tshy": "^3.0.2",
@@ -32,10 +31,10 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
+    "@colordx/core": "^6.3.0",
     "@jimp/core": "workspace:*",
     "@jimp/types": "workspace:*",
     "@jimp/utils": "workspace:*",
-    "tinycolor2": "^1.6.0",
     "zod": "^3.23.8"
   },
   "tshy": {

--- a/plugins/plugin-color/src/index.ts
+++ b/plugins/plugin-color/src/index.ts
@@ -1,4 +1,4 @@
-import tinyColor from "tinycolor2";
+import { Colordx } from "@colordx/core";
 import { clone, limit255, scan } from "@jimp/utils";
 import { Edge, JimpClass, RGBColor } from "@jimp/types";
 import { z } from "zod";
@@ -799,7 +799,7 @@ export const methods = {
 
     actions = actions.map((action) => {
       if (action.apply === "xor" || action.apply === "mix") {
-        action.params[0] = tinyColor(action.params[0]).toRgb();
+        action.params[0] = new Colordx(action.params[0]).toRgb();
       }
 
       return action;
@@ -835,21 +835,43 @@ export const methods = {
         } else if (action.apply === "blue") {
           clr.b = colorModifier("b", action.params[0]);
         } else {
-          if (action.apply === "hue") {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            action.apply = "spin";
+          const amount = (action.params?.[0] as number | undefined) ?? 10;
+          const color = new Colordx(clr);
+
+          switch (action.apply) {
+            case "hue":
+            case "spin":
+              clr = color.rotate(amount).toRgb();
+              break;
+            case "lighten":
+              clr = color.lighten(amount / 100).toRgb();
+              break;
+            case "darken":
+              clr = color.darken(amount / 100).toRgb();
+              break;
+            case "saturate":
+              clr = color.saturate(amount / 100).toRgb();
+              break;
+            case "desaturate":
+              clr = color.desaturate(amount / 100).toRgb();
+              break;
+            case "greyscale":
+              clr = color.grayscale().toRgb();
+              break;
+            case "brighten": {
+              const offset = -Math.round(255 * -(amount / 100));
+              clr = {
+                r: limit255(clr.r! + offset),
+                g: limit255(clr.g! + offset),
+                b: limit255(clr.b! + offset),
+              };
+              break;
+            }
+            default:
+              throw new Error(
+                "action " + (action as ColorAction).apply + " not supported"
+              );
           }
-
-          const tnyClr = tinyColor(clr);
-          const fn = tnyClr[action.apply].bind(tnyClr);
-
-          if (!fn) {
-            throw new Error("action " + action.apply + " not supported");
-          }
-
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          clr = (fn as any)(...(action.params || [])).toRgb();
         }
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,12 +495,12 @@ importers:
 
   packages/utils:
     dependencies:
+      '@colordx/core':
+        specifier: ^6.3.0
+        version: 6.3.0
       '@jimp/types':
         specifier: workspace:*
         version: link:../types
-      tinycolor2:
-        specifier: ^1.6.0
-        version: 1.6.0
     devDependencies:
       '@jimp/config-eslint':
         specifier: workspace:*
@@ -511,9 +511,6 @@ importers:
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.48
-      '@types/tinycolor2':
-        specifier: ^1.4.6
-        version: 1.4.6
       eslint:
         specifier: ^9.9.1
         version: 9.9.1
@@ -912,6 +909,9 @@ importers:
 
   plugins/plugin-color:
     dependencies:
+      '@colordx/core':
+        specifier: ^6.3.0
+        version: 6.3.0
       '@jimp/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -921,9 +921,6 @@ importers:
       '@jimp/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      tinycolor2:
-        specifier: ^1.6.0
-        version: 1.6.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -949,9 +946,6 @@ importers:
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.48
-      '@types/tinycolor2':
-        specifier: ^1.4.6
-        version: 1.4.6
       '@vitest/browser':
         specifier: ^2.0.5
         version: 2.0.5(playwright@1.46.1)(typescript@5.5.4)(vitest@2.0.5)
@@ -2117,6 +2111,9 @@ packages:
 
   '@bundled-es-modules/tough-cookie@0.1.6':
     resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
+
+  '@colordx/core@6.3.0':
+    resolution: {integrity: sha512-skoCSPWAZTfawy3t6Qk1lqXsx1OPb/mCNYBpbG667+PmXIc7kt+rhjoS2SmYywaW9fnKaufPG59NztX6jpRNaw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7521,6 +7518,8 @@ snapshots:
     dependencies:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
+
+  '@colordx/core@6.3.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
I am maintainer of colordx, a modern colour library for JS.

I thought it would be useful to open a transition PR, to make the web a better place and to make sure jimp works on a fresh stack.

color() builds one colour object per pixel, so this swap makes it about 10x faster.

Here is a demo comparing both:
https://dkryaklin.github.io/colordx/